### PR TITLE
fix CTLParser to allow building with flex++ 2.6.4

### DIFF
--- a/WN/SOURCE/RGMEDD2/CTLParser.yy
+++ b/WN/SOURCE/RGMEDD2/CTLParser.yy
@@ -36,9 +36,9 @@ extern bool print_CTL_counterexamples;
 void yyerror(const char *str) {
   cout<<"Parse error at \"" << lexer->YYText() << "\": " << str << "." << endl;
 }
- 
+
 int yylex(void){
-    int i = lexer->yylex(); 
+    int i = lexer->mmlex();
     return i;
 }
 extern int yyparse(void);


### PR DESCRIPTION
The latest version of Flex++ has modified the handling of `yy_` attributes, resulting in a compilation error for the RGMEDD2 tool. For reference, see: https://github.com/greatspn/SOURCES/issues/5.

A possible solution to this is to use the prefixed function `mmlex` inside the CTLParser.yy file. This results in a successful build with flex++ 2.6.4.